### PR TITLE
fixed problem with [module]:event(init)

### DIFF
--- a/src/n2o_vnode.erl
+++ b/src/n2o_vnode.erl
@@ -22,7 +22,9 @@ debug(Name,Topic,BERT,Address,Return) ->
 send(C,T,M) -> send(C, T, M, [{qos,2}]).
 send(C,T,M,Opts) -> emqttc:publish(C, T, M, Opts).
 fix(<<"index">>) -> index;
-fix(Module) -> login.
+fix(Module) ->
+  %io:format("Module: ~p~n",[Module]),
+  list_to_atom(binary_to_list(Module)).
 
 % Performed on VNODE init
 gen_name(Pos) when is_integer(Pos)->


### PR DESCRIPTION
event(init) worked only for index and login modules. If create custom module (e.g. welcome.erl), then login:event(init) was executed instead of welcome:event(init).